### PR TITLE
Implement embed installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+test/output
 test/vimtest
 profile_file*
 .coverage_covimerage

--- a/README.md
+++ b/README.md
@@ -15,6 +15,38 @@ Among the features:
 * A callback mechanism allows asynchronous execution. The data provider can
   generate data asynchronously, and send it to the view through a callback.
 * Pure VimScript implementation, self-contained library.
+* Easy to embed in other plugins without external dependencies.
+
+Install
+=======
+
+Yggdrasil can be either installed as an external dependency (as a regular vim
+plugin) or it can be embedded within another plugin's file structure. The
+latter solution allows to have an own copy of Yggdrasil, avoiding to rely on an
+external dependency with its potential issues.
+
+To embed Yggdrasil in your plugin, run the `YggdrasilPlant` command, specifying
+the root directory of your vim plugin, and optionally a name to be used as a
+namespace (by default, the name of the root directory). For instance, if your
+plugin's root folder (containing the `autoload`, `plugin`, `doc` folders etc.)
+is `/foo/myplugin`, by calling:
+```
+:YggdrasilPlant /foo/myplugin
+```
+a copy of Yggdrasil will be installed in
+`/foo/myplugin/autoload/myplugin/yggdrasil`, and it can be used as
+```viml
+" Call an Yggdrasil function in your plugin code
+call myplugin#yggdrasil#tree#new(provider)
+```
+
+If for some reason you want to use a different namespace than the name of the
+root folder of your plugin, pass an optional argument to specify it. For
+instance, a call to
+```
+:YggdrasilPlant /foo/myplugin bar
+```
+will install a copy of Yggdrasil in `/foo/myplugin/autoload/bar/yggdrasil`.
 
 Example
 =======

--- a/autoload/yggdrasil/embedder.vim
+++ b/autoload/yggdrasil/embedder.vim
@@ -1,0 +1,44 @@
+let s:yggdrasil_autoload_root = expand('<sfile>:p:h:h')
+
+" Autoload files to be installed
+let s:yggdrasil_autoload_files = [
+\   'yggdrasil/tree.vim',
+\ ]
+
+" Install an autoload file in the given destination folder
+function! s:install_autoload_file(file, destination_folder) abort
+    let l:source_file = simplify(s:yggdrasil_autoload_root . '/' . a:file)
+    let l:destination_file = simplify(a:destination_folder . '/' . a:file)
+    let l:prefix = fnamemodify(a:destination_folder, ':t')
+
+    " Read source file
+    let l:lines = readfile(l:source_file)
+
+    " Replace the autoload prefix
+    let l:lines = map(
+    \   l:lines,
+    \   {_, l -> substitute(l, '\V\<yggdrasil#', l:prefix . '#yggdrasil#', 'g')}
+    \ )
+
+    " Write destination file
+    call mkdir(fnamemodify(l:destination_file, ':h'), 'p')
+    call writefile(l:lines, l:destination_file)
+endfunction
+
+" Embed Yggdrasil in another plugin's file structure.
+"
+" A plugin name, to be used as a namespace, can be optionally specified.
+" The folder name will be used if missing.
+function! yggdrasil#embedder#plant_tree(plugin_dir, ...) abort
+    if !isdirectory(a:plugin_dir)
+        throw 'Yggdrasil: cannot read target plugin directory'
+    endif
+
+    let l:plugin_name = a:0 > 0 ? a:1 : fnamemodify(a:plugin_dir, ':t')
+
+    let l:destination_folder = simplify(a:plugin_dir . '/autoload/' . l:plugin_name)
+
+    for l:file in s:yggdrasil_autoload_files
+        call s:install_autoload_file(l:file, l:destination_folder)
+    endfor
+endfunction

--- a/doc/yggdrasil.txt
+++ b/doc/yggdrasil.txt
@@ -5,6 +5,7 @@
 CONTENTS                                                  *yggdrasil-contents*
 
     Introduction.....................|yggdrasil-introduction|
+    Installation.....................|yggdrasil-installation|
     Functions........................|yggdrasil-functions|
     Options..........................|yggdrasil-options|
       g:yggdrasil_no_default_maps....|g:yggdrasil_no_default_maps|
@@ -24,6 +25,19 @@ a callback mechanism.
 The tree view is populated using a provider object with an API similar to
 VSCode's TreeDataProvider
 (https://code.visualstudio.com/api/references/vscode-api#TreeDataProvider).
+
+==============================================================================
+Installation                                          *yggdrasil-installation*
+
+Yggdrasil can be installed in two different ways, either as an external
+dependency, or it can be embedded in another plugin's file structure. To be
+used as an external dependency, Yggdrasil can be installed as a regular
+plugin.
+
+To embed Yggdrasil within a foreign plugin's file structure, install Yggdrasil
+locally, then use the |YggdrasilPlant| command, specifying the root folder of
+the host plugin, and optionally a name to be used as a namespace (by default,
+the name of the host plugin root folder).
 
 ==============================================================================
 Functions                                                *yggdrasil-functions*
@@ -144,6 +158,29 @@ yggdrasil#tree#new({provider})                            *yggdrasil#tree#new*
     \ }
 
     call yggdrasil#tree#new(s:provider)
+<
+
+==============================================================================
+Commands                                                  *yggdrasil-commands*
+
+YggdrasilPlant {plugin_folder} [{plugin_name}]                *YggdrasilPlant*
+
+    Embed Yggdrasil in a foreign plugin's file structure. The foreign plugin
+    file structure is rooted in {plugin_folder}, that contains the autoload,
+    plugin, doc folders etc. An optional {plugin_name} can be passed as
+    argument, if not the name of the {plugin_folder} will be used.
+
+    The command will install a copy of the Yggdrasil autoload files in the
+    autoload folder of the foreign plugin. The autoload prefix will be in
+    the form {plugin_name}#yggdrasil#file_name#function_name().
+
+    Example:
+>
+    " Will install Yggdrasil in /foo/myplugin/autoload/myplugin/yggdrasil
+    YggdrasilPlant /foo/myplugin
+
+    " Will install Yggdrasil il /foo/myplugin/autoload/bar/yggdrasil
+    YggdrasilPlant /foo/myplugin bar
 <
 
 ==============================================================================

--- a/doc/yggdrasil.txt
+++ b/doc/yggdrasil.txt
@@ -81,11 +81,9 @@ yggdrasil#tree#new({provider})                            *yggdrasil#tree#new*
 
     The tree object has some member functions that allow to interact with it:
 
-     * set_collapsed_under_cursor({collapsed}, {recursive})
+     * set_collapsed_under_cursor({collapsed})
        If {collapsed} is 1, collapse the node currently under cursor, if it is
-       0 expand it, if it is -1 toggle its collapsing state. If {recursive} is
-       true, the change is propagated recursively to the whole subtree rooted
-       in the node under the cursor.
+       0 expand it, if it is -1 toggle its collapsing state.
 
      * exec_node_under_cursor()
        Trigger the action associated to the execution of the node currently
@@ -211,15 +209,11 @@ under the cursor in a Yggdrasil buffer are:
     <Plug>(yggdrasil-toggle-node)
     <Plug>(yggdrasil-open-node)
     <Plug>(yggdrasil-close-node)
-    <Plug>(yggdrasil-open-subtree)
-    <Plug>(yggdrasil-close-subtree)
     <Plug>(yggdrasil-execute-node)
 
 The following key bindings are provided out-of-the-box:
 >
     nmap <silent> <buffer> o    <Plug>(yggdrasil-toggle-node)
-    nmap <silent> <buffer> O    <Plug>(yggdrasil-open-subtree)
-    nmap <silent> <buffer> C    <Plug>(yggdrasil-close-subtree)
     nmap <silent> <buffer> <cr> <Plug>(yggdrasil-execute-node)
     nnoremap <silent> <buffer> q :q<cr>
 <

--- a/plugin/yggdrasil.vim
+++ b/plugin/yggdrasil.vim
@@ -1,0 +1,6 @@
+if exists('g:vim_yggdrasil_plugin_loaded')
+    finish
+endif
+let g:vim_yggdrasil_plugin_loaded = 1
+
+command! -nargs=+ YggdrasilPlant :call yggdrasil#embedder#plant_tree(<f-args>)

--- a/test/test_embedder.vader
+++ b/test/test_embedder.vader
@@ -1,0 +1,54 @@
+Before:
+  call system('rm -rf test/output/*')
+
+  let plugin_root = 'test/output/myplugin'
+
+  function! Assert_installation(plugin_root, plugin_prefix) abort
+    let l:installed_file = a:plugin_root . '/autoload/' . a:plugin_prefix . '/yggdrasil/tree.vim'
+    let l:expected_line = '\Vfunction! ' . a:plugin_prefix . '#yggdrasil#tree#new(provider) abort'
+
+    Assert
+    \   filereadable(l:installed_file),
+    \   'File "' . l:installed_file . '" not installed'
+
+    let l:lines = readfile(l:installed_file)
+
+    Assert
+    \   len(filter(l:lines, {i, l -> l =~# l:expected_line})) > 0,
+    \   'Autoload prefix not set correctly in "' . l:installed_file . '"'
+  endfunction
+
+After:
+  unlet! plugin_root
+  unlet! plugin_prefix
+  delfunction Assert_installation
+
+Execute(Test install):
+  call mkdir(plugin_root, 'p')
+  let plugin_prefix = fnamemodify(plugin_root, ':t')
+
+  exec 'YggdrasilPlant ' . plugin_root
+
+  call Assert_installation(plugin_root, plugin_prefix)
+
+Execute(Test install with custom prefix):
+  call mkdir(plugin_root, 'p')
+  let plugin_prefix = 'myprefix'
+
+  exec 'YggdrasilPlant ' . plugin_root . ' ' . plugin_prefix
+
+  call Assert_installation(plugin_root, plugin_prefix)
+
+Execute(Test double loading):
+  unlet g:vim_yggdrasil_plugin_loaded
+  source plugin/yggdrasil.vim
+
+  AssertEqual 1, g:vim_yggdrasil_plugin_loaded
+
+  source plugin/yggdrasil.vim
+
+  AssertEqual 1, g:vim_yggdrasil_plugin_loaded
+
+Execute(Test exception on bad plugin root):
+  AssertThrows YggdrasilPlant test/output/myplugin
+  AssertEqual 'Yggdrasil: cannot read target plugin directory', g:vader_exception

--- a/test/test_filetype.vader
+++ b/test/test_filetype.vader
@@ -43,31 +43,21 @@ Execute(test filetype_settings):
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-toggle-node)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(-1, v:false)<CR>'
+  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(-1)<CR>'
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-open-node)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:false, v:false)<CR>'
+  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:false)<CR>'
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-close-node)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:true, v:false)<CR>'
-  AssertMapping
-  \   'nmap',
-  \   '<Plug>(yggdrasil-open-subtree)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:false, v:true)<CR>'
-  AssertMapping
-  \   'nmap',
-  \   '<Plug>(yggdrasil-close-subtree)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:true, v:true)<CR>'
+  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:true)<CR>'
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-execute-node)',
   \   ':call b:yggdrasil_tree.exec_node_under_cursor()<CR>'
 
   AssertMapping 'nmap', 'o', '<Plug>(yggdrasil-toggle-node)'
-  AssertMapping 'nmap', 'O', '<Plug>(yggdrasil-open-subtree)'
-  AssertMapping 'nmap', 'C', '<Plug>(yggdrasil-close-subtree)'
   AssertMapping 'nmap', '<CR>', '<Plug>(yggdrasil-execute-node)'
   AssertMapping 'nmap', 'q', ':q<CR>'
 
@@ -78,7 +68,5 @@ Execute(test filetype_settings with g:yggdrasil_no_default_maps):
   call Filetype_settings()
 
   AssertNoMapping 'nmap', 'o'
-  AssertNoMapping 'nmap', 'O'
-  AssertNoMapping 'nmap', 'C'
   AssertNoMapping 'nmap', '<CR>'
   AssertNoMapping 'nmap', 'q'

--- a/test/test_filetype.vader
+++ b/test/test_filetype.vader
@@ -16,10 +16,10 @@ Execute(test filetype_syntax):
 
   call Filetype_syntax()
 
-  syntax list YggdrasilId
+  syntax list YggdrasilMarkLeaf
   syntax list YggdrasilMarkCollapsed
   syntax list YggdrasilMarkExpanded
-  syntax list YggdrasilLabel
+  syntax list YggdrasilNode
 
 Execute(test filetype_settings):
   let Filetype_settings = GetFunction(b:script, 'filetype_settings')
@@ -28,8 +28,6 @@ Execute(test filetype_settings):
 
   AssertEqual 'wipe', &bufhidden
   AssertEqual 'nofile', &buftype
-  AssertEqual 'nvic', &concealcursor
-  AssertEqual 3, &conceallevel
   AssertEqual 0, &foldcolumn
   AssertEqual 'manual', &foldmethod
   AssertEqual 0, &buflisted

--- a/test/test_tree.vader
+++ b/test/test_tree.vader
@@ -22,6 +22,7 @@ Before:
   let parent = 'parent'
 
 After:
+  set filetype=
   unlet! b:yggdrasil_tree
   unlet! b:script
 
@@ -37,6 +38,7 @@ After:
   unlet! Node_level
   unlet! Node_render
   unlet! Node_fetch_children
+  unlet! Tree_render
   unlet! exec_mock
   unlet! get_children_mock
   bwipeout!
@@ -77,10 +79,11 @@ Execute(Test s:node_render):
   \  'object': {},
   \  'tree': {
   \    'provider': provider,
+  \    'index': [],
   \  },
   \  'tree_item': {
-  \     'label': 'foobar',
-  \  }
+  \    'label': 'foobar',
+  \  },
   \ }
   let child = {
   \  'id': 1,
@@ -92,39 +95,40 @@ Execute(Test s:node_render):
   \  'object': {},
   \  'tree': {
   \    'provider': provider,
+  \    'index': [],
   \  },
   \  'tree_item': {
-  \     'label': 'child',
-  \  }
+  \    'label': "child\nmultiline",
+  \  },
   \ }
 
   let repr = node.render(0)
 
-  AssertEqual "  foobar [0]", repr
+  AssertEqual "• foobar", repr
   AssertEqual 0, get_children_mock.count
 
   let repr = node.render(1)
 
-  AssertEqual "    foobar [0]", repr
+  AssertEqual "  • foobar", repr
   AssertEqual 0, get_children_mock.count
 
   let node.lazy_open = 1
   let repr = node.render(1)
 
-  AssertEqual "  ▸ foobar [0]", repr
+  AssertEqual "  ▸ foobar", repr
   AssertEqual 0, get_children_mock.count
 
   let node.collapsed = 0
   let repr = node.render(1)
 
-  AssertEqual "  ▾ foobar [0]", repr
+  AssertEqual "  ▾ foobar", repr
   AssertEqual 1, get_children_mock.count
 
   let node.lazy_open = 0
   call add(node.children, child)
   let repr = node.render(1)
 
-  AssertEqual "  ▾ foobar [0]\n      child [1]", repr
+  AssertEqual "  ▾ foobar\n    • child\n      multiline", repr
   AssertEqual 1, get_children_mock.count
 
 Execute(Test s:node_level):
@@ -222,6 +226,27 @@ Execute(Test s:node_set_collapsed recursive):
 
   AssertEqual 1, root.collapsed
   AssertEqual 1, child.collapsed
+
+Execute(Test s:tree_render filetype guard):
+  let Tree_render = GetFunction(b:script, 'tree_render')
+  let node = {
+  \  'id': 0,
+  \  'children': [],
+  \  'collapsed': 0,
+  \  'lazy_open': 0,
+  \  'object': 0,
+  \  'tree': b:yggdrasil_tree,
+  \ }
+
+  let render_mock = GetFunctionMock()
+  let b:yggdrasil_tree.root.render = render_mock.function
+  set filetype=c
+
+  call Tree_render(b:yggdrasil_tree)
+
+  Assert
+  \   render_mock.count == 0,
+  \   'Rendering function called outside yggdrasil filetype'
 
 Execute(Test yggdrasil#tree#new):
   call yggdrasil#tree#new(provider)

--- a/test/test_tree.vader
+++ b/test/test_tree.vader
@@ -37,7 +37,6 @@ After:
   unlet! Node_find
   unlet! Node_level
   unlet! Node_render
-  unlet! Node_fetch_children
   unlet! Tree_render
   unlet! exec_mock
   unlet! get_children_mock
@@ -64,7 +63,6 @@ Execute(Test s:node_new):
 
 Execute(Test s:node_render):
   let Node_render = GetFunction(b:script, 'node_render')
-  let Node_fetch_children = GetFunction(b:script, 'node_fetch_children')
   let get_children_mock = GetFunctionMock()
 
   let provider.getChildren = get_children_mock.function
@@ -75,7 +73,6 @@ Execute(Test s:node_render):
   \  'children': [],
   \  'lazy_open': 0,
   \  'render': Node_render,
-  \  'fetch_children': Node_fetch_children,
   \  'object': {},
   \  'tree': {
   \    'provider': provider,
@@ -91,7 +88,6 @@ Execute(Test s:node_render):
   \  'children': [],
   \  'lazy_open': 0,
   \  'render': Node_render,
-  \  'fetch_children': Node_fetch_children,
   \  'object': {},
   \  'tree': {
   \    'provider': provider,
@@ -176,56 +172,21 @@ Execute(Test s:node_set_collapsed):
   \  'set_collapsed': Node_set_collapsed,
   \ }
 
-  call node.set_collapsed(0, 0)
+  call node.set_collapsed(0)
 
   AssertEqual 0, node.collapsed
 
-  call node.set_collapsed(1, 0)
+  call node.set_collapsed(1)
 
   AssertEqual 1, node.collapsed
 
-  call node.set_collapsed(-1, 0)
+  call node.set_collapsed(-1)
 
   AssertEqual 0, node.collapsed
 
-  call node.set_collapsed(-1, 0)
+  call node.set_collapsed(-1)
 
   AssertEqual 1, node.collapsed
-
-Execute(Test s:node_set_collapsed recursive):
-  let Node_set_collapsed = GetFunction(b:script, 'node_set_collapsed')
-  let child = {
-  \  'collapsed': 0,
-  \  'lazy_open': 0,
-  \  'set_collapsed': Node_set_collapsed,
-  \  'children': [],
-  \ }
-  let root = {
-  \  'collapsed': 0,
-  \  'lazy_open': 0,
-  \  'set_collapsed': Node_set_collapsed,
-  \  'children': [child],
-  \ }
-
-  call root.set_collapsed(0, 1)
-
-  AssertEqual 0, root.collapsed
-  AssertEqual 0, child.collapsed
-
-  call root.set_collapsed(1, 1)
-
-  AssertEqual 1, root.collapsed
-  AssertEqual 1, child.collapsed
-
-  call root.set_collapsed(-1, 1)
-
-  AssertEqual 0, root.collapsed
-  AssertEqual 0, child.collapsed
-
-  call root.set_collapsed(-1, 1)
-
-  AssertEqual 1, root.collapsed
-  AssertEqual 1, child.collapsed
 
 Execute(Test s:tree_render filetype guard):
   let Tree_render = GetFunction(b:script, 'tree_render')
@@ -269,7 +230,7 @@ Execute(Test s:tree_set_collapsed_under_cursor expand):
   AssertEqual 1, b:yggdrasil_tree.root.lazy_open
 
   call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
 
   AssertEqual 0, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
@@ -278,7 +239,7 @@ Execute(Test s:tree_set_collapsed_under_cursor expand):
   AssertEqual 'Label of node 2', b:yggdrasil_tree.root.children[1].tree_item.label
 
   call cursor(3, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
 
   let node = b:yggdrasil_tree.root.children[1]
 
@@ -290,12 +251,12 @@ Execute(Test s:tree_set_collapsed_under_cursor collapse):
   call yggdrasil#tree#new(provider)
 
   call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
 
   AssertEqual 0, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
 
-  call b:yggdrasil_tree.set_collapsed_under_cursor(1, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(1)
 
   AssertEqual 1, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
@@ -304,43 +265,15 @@ Execute(Test s:tree_set_collapsed_under_cursor flip):
   call yggdrasil#tree#new(provider)
 
   call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(-1, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(-1)
 
   AssertEqual 0, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
 
-  call b:yggdrasil_tree.set_collapsed_under_cursor(-1, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(-1)
 
   AssertEqual 1, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
-
-Execute(Test s:tree_set_collapsed_under_cursor recursive):
-  call yggdrasil#tree#new(provider)
-
-  call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 1)
-
-  let root = b:yggdrasil_tree.root
-
-  AssertEqual 'Label of node 1', root.children[0].tree_item.label
-  AssertEqual 'Label of node 2', root.children[1].tree_item.label
-  AssertEqual 'Label of node 3', root.children[0].children[0].tree_item.label
-  AssertEqual 'Label of node 4', root.children[1].children[0].tree_item.label
-  AssertEqual 'Label of node 5', root.children[1].children[1].tree_item.label
-
-  AssertEqual 0, root.children[0].collapsed
-  AssertEqual 0, root.children[1].collapsed
-  AssertEqual 0, root.children[0].children[0].collapsed
-  AssertEqual 0, root.children[1].children[0].collapsed
-  AssertEqual 0, root.children[1].children[1].collapsed
-
-  call b:yggdrasil_tree.set_collapsed_under_cursor(1, 1)
-
-  AssertEqual 1, root.children[0].collapsed
-  AssertEqual 1, root.children[1].collapsed
-  AssertEqual 1, root.children[0].children[0].collapsed
-  AssertEqual 1, root.children[1].children[0].collapsed
-  AssertEqual 1, root.children[1].children[1].collapsed
 
 Execute(Test s:tree_exec_node_under_cursor):
   call yggdrasil#tree#new(provider)
@@ -350,7 +283,7 @@ Execute(Test s:tree_exec_node_under_cursor):
 
   AssertMessage 'Calling object 0!'
 
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
   call cursor(2, 1)
 
   call b:yggdrasil_tree.exec_node_under_cursor()


### PR DESCRIPTION
Implement an installation mechanism that allows to embed Yggdrasil similarly to the `:Vitalize` command in [vital.vim](https://github.com/vim-jp/vital.vim).

Acceptance criteria:
* [x] Implement installer
* [x] Update tests
* [x] Update README.md
* [x] Update documentation

Resolves #5