### PR TITLE
Implement LUT to retrieve the node under cursor

### DIFF
--- a/doc/yggdrasil.txt
+++ b/doc/yggdrasil.txt
@@ -81,11 +81,9 @@ yggdrasil#tree#new({provider})                            *yggdrasil#tree#new*
 
     The tree object has some member functions that allow to interact with it:
 
-     * set_collapsed_under_cursor({collapsed}, {recursive})
+     * set_collapsed_under_cursor({collapsed})
        If {collapsed} is 1, collapse the node currently under cursor, if it is
-       0 expand it, if it is -1 toggle its collapsing state. If {recursive} is
-       true, the change is propagated recursively to the whole subtree rooted
-       in the node under the cursor.
+       0 expand it, if it is -1 toggle its collapsing state.
 
      * exec_node_under_cursor()
        Trigger the action associated to the execution of the node currently
@@ -211,15 +209,11 @@ under the cursor in a Yggdrasil buffer are:
     <Plug>(yggdrasil-toggle-node)
     <Plug>(yggdrasil-open-node)
     <Plug>(yggdrasil-close-node)
-    <Plug>(yggdrasil-open-subtree)
-    <Plug>(yggdrasil-close-subtree)
     <Plug>(yggdrasil-execute-node)
 
 The following key bindings are provided out-of-the-box:
 >
     nmap <silent> <buffer> o    <Plug>(yggdrasil-toggle-node)
-    nmap <silent> <buffer> O    <Plug>(yggdrasil-open-subtree)
-    nmap <silent> <buffer> C    <Plug>(yggdrasil-close-subtree)
     nmap <silent> <buffer> <cr> <Plug>(yggdrasil-execute-node)
     nnoremap <silent> <buffer> q :q<cr>
 <

--- a/test/test_filetype.vader
+++ b/test/test_filetype.vader
@@ -43,31 +43,21 @@ Execute(test filetype_settings):
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-toggle-node)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(-1, v:false)<CR>'
+  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(-1)<CR>'
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-open-node)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:false, v:false)<CR>'
+  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:false)<CR>'
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-close-node)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:true, v:false)<CR>'
-  AssertMapping
-  \   'nmap',
-  \   '<Plug>(yggdrasil-open-subtree)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:false, v:true)<CR>'
-  AssertMapping
-  \   'nmap',
-  \   '<Plug>(yggdrasil-close-subtree)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:true, v:true)<CR>'
+  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:true)<CR>'
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-execute-node)',
   \   ':call b:yggdrasil_tree.exec_node_under_cursor()<CR>'
 
   AssertMapping 'nmap', 'o', '<Plug>(yggdrasil-toggle-node)'
-  AssertMapping 'nmap', 'O', '<Plug>(yggdrasil-open-subtree)'
-  AssertMapping 'nmap', 'C', '<Plug>(yggdrasil-close-subtree)'
   AssertMapping 'nmap', '<CR>', '<Plug>(yggdrasil-execute-node)'
   AssertMapping 'nmap', 'q', ':q<CR>'
 
@@ -78,7 +68,5 @@ Execute(test filetype_settings with g:yggdrasil_no_default_maps):
   call Filetype_settings()
 
   AssertNoMapping 'nmap', 'o'
-  AssertNoMapping 'nmap', 'O'
-  AssertNoMapping 'nmap', 'C'
   AssertNoMapping 'nmap', '<CR>'
   AssertNoMapping 'nmap', 'q'

--- a/test/test_filetype.vader
+++ b/test/test_filetype.vader
@@ -16,10 +16,10 @@ Execute(test filetype_syntax):
 
   call Filetype_syntax()
 
-  syntax list YggdrasilId
+  syntax list YggdrasilMarkLeaf
   syntax list YggdrasilMarkCollapsed
   syntax list YggdrasilMarkExpanded
-  syntax list YggdrasilLabel
+  syntax list YggdrasilNode
 
 Execute(test filetype_settings):
   let Filetype_settings = GetFunction(b:script, 'filetype_settings')
@@ -28,8 +28,6 @@ Execute(test filetype_settings):
 
   AssertEqual 'wipe', &bufhidden
   AssertEqual 'nofile', &buftype
-  AssertEqual 'nvic', &concealcursor
-  AssertEqual 3, &conceallevel
   AssertEqual 0, &foldcolumn
   AssertEqual 'manual', &foldmethod
   AssertEqual 0, &buflisted

--- a/test/test_tree.vader
+++ b/test/test_tree.vader
@@ -22,6 +22,7 @@ Before:
   let parent = 'parent'
 
 After:
+  set filetype=
   unlet! b:yggdrasil_tree
   unlet! b:script
 
@@ -37,6 +38,7 @@ After:
   unlet! Node_level
   unlet! Node_render
   unlet! Node_fetch_children
+  unlet! Tree_render
   unlet! exec_mock
   unlet! get_children_mock
   bwipeout!
@@ -77,10 +79,11 @@ Execute(Test s:node_render):
   \  'object': {},
   \  'tree': {
   \    'provider': provider,
+  \    'index': [],
   \  },
   \  'tree_item': {
-  \     'label': 'foobar',
-  \  }
+  \    'label': 'foobar',
+  \  },
   \ }
   let child = {
   \  'id': 1,
@@ -92,39 +95,40 @@ Execute(Test s:node_render):
   \  'object': {},
   \  'tree': {
   \    'provider': provider,
+  \    'index': [],
   \  },
   \  'tree_item': {
-  \     'label': 'child',
-  \  }
+  \    'label': "child\nmultiline",
+  \  },
   \ }
 
   let repr = node.render(0)
 
-  AssertEqual "  foobar [0]", repr
+  AssertEqual "• foobar", repr
   AssertEqual 0, get_children_mock.count
 
   let repr = node.render(1)
 
-  AssertEqual "    foobar [0]", repr
+  AssertEqual "  • foobar", repr
   AssertEqual 0, get_children_mock.count
 
   let node.lazy_open = 1
   let repr = node.render(1)
 
-  AssertEqual "  ▸ foobar [0]", repr
+  AssertEqual "  ▸ foobar", repr
   AssertEqual 0, get_children_mock.count
 
   let node.collapsed = 0
   let repr = node.render(1)
 
-  AssertEqual "  ▾ foobar [0]", repr
+  AssertEqual "  ▾ foobar", repr
   AssertEqual 1, get_children_mock.count
 
   let node.lazy_open = 0
   call add(node.children, child)
   let repr = node.render(1)
 
-  AssertEqual "  ▾ foobar [0]\n      child [1]", repr
+  AssertEqual "  ▾ foobar\n    • child\n      multiline", repr
   AssertEqual 1, get_children_mock.count
 
 Execute(Test s:node_level):
@@ -222,6 +226,27 @@ Execute(Test s:node_set_collapsed recursive):
 
   AssertEqual 1, root.collapsed
   AssertEqual 1, child.collapsed
+
+Execute(Test s:tree_render filetype guard):
+  let Tree_render = GetFunction(b:script, 'tree_render')
+  let node = {
+  \  'id': 0,
+  \  'children': [],
+  \  'collapsed': 0,
+  \  'lazy_open': 0,
+  \  'object': 0,
+  \  'tree': b:yggdrasil_tree,
+  \ }
+
+  let render_mock = GetFunctionMock()
+  let b:yggdrasil_tree.root.render = render_mock.function
+  set filetype=c
+
+  call Tree_render(b:yggdrasil_tree)
+
+  Assert
+  \   render_mock.count == 0,
+  \   'Rendering function called outside yggdrasil filetype'
 
 Execute(Test yggdrasil#tree#new):
   call yggdrasil#tree#new(provider)

--- a/test/test_tree.vader
+++ b/test/test_tree.vader
@@ -37,7 +37,6 @@ After:
   unlet! Node_find
   unlet! Node_level
   unlet! Node_render
-  unlet! Node_fetch_children
   unlet! Tree_render
   unlet! exec_mock
   unlet! get_children_mock
@@ -64,7 +63,6 @@ Execute(Test s:node_new):
 
 Execute(Test s:node_render):
   let Node_render = GetFunction(b:script, 'node_render')
-  let Node_fetch_children = GetFunction(b:script, 'node_fetch_children')
   let get_children_mock = GetFunctionMock()
 
   let provider.getChildren = get_children_mock.function
@@ -75,7 +73,6 @@ Execute(Test s:node_render):
   \  'children': [],
   \  'lazy_open': 0,
   \  'render': Node_render,
-  \  'fetch_children': Node_fetch_children,
   \  'object': {},
   \  'tree': {
   \    'provider': provider,
@@ -91,7 +88,6 @@ Execute(Test s:node_render):
   \  'children': [],
   \  'lazy_open': 0,
   \  'render': Node_render,
-  \  'fetch_children': Node_fetch_children,
   \  'object': {},
   \  'tree': {
   \    'provider': provider,
@@ -176,56 +172,21 @@ Execute(Test s:node_set_collapsed):
   \  'set_collapsed': Node_set_collapsed,
   \ }
 
-  call node.set_collapsed(0, 0)
+  call node.set_collapsed(0)
 
   AssertEqual 0, node.collapsed
 
-  call node.set_collapsed(1, 0)
+  call node.set_collapsed(1)
 
   AssertEqual 1, node.collapsed
 
-  call node.set_collapsed(-1, 0)
+  call node.set_collapsed(-1)
 
   AssertEqual 0, node.collapsed
 
-  call node.set_collapsed(-1, 0)
+  call node.set_collapsed(-1)
 
   AssertEqual 1, node.collapsed
-
-Execute(Test s:node_set_collapsed recursive):
-  let Node_set_collapsed = GetFunction(b:script, 'node_set_collapsed')
-  let child = {
-  \  'collapsed': 0,
-  \  'lazy_open': 0,
-  \  'set_collapsed': Node_set_collapsed,
-  \  'children': [],
-  \ }
-  let root = {
-  \  'collapsed': 0,
-  \  'lazy_open': 0,
-  \  'set_collapsed': Node_set_collapsed,
-  \  'children': [child],
-  \ }
-
-  call root.set_collapsed(0, 1)
-
-  AssertEqual 0, root.collapsed
-  AssertEqual 0, child.collapsed
-
-  call root.set_collapsed(1, 1)
-
-  AssertEqual 1, root.collapsed
-  AssertEqual 1, child.collapsed
-
-  call root.set_collapsed(-1, 1)
-
-  AssertEqual 0, root.collapsed
-  AssertEqual 0, child.collapsed
-
-  call root.set_collapsed(-1, 1)
-
-  AssertEqual 1, root.collapsed
-  AssertEqual 1, child.collapsed
 
 Execute(Test s:tree_render filetype guard):
   let Tree_render = GetFunction(b:script, 'tree_render')
@@ -269,7 +230,7 @@ Execute(Test s:tree_set_collapsed_under_cursor expand):
   AssertEqual 1, b:yggdrasil_tree.root.lazy_open
 
   call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
 
   AssertEqual 0, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
@@ -278,7 +239,7 @@ Execute(Test s:tree_set_collapsed_under_cursor expand):
   AssertEqual 'Label of node 2', b:yggdrasil_tree.root.children[1].tree_item.label
 
   call cursor(3, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
 
   let node = b:yggdrasil_tree.root.children[1]
 
@@ -290,12 +251,12 @@ Execute(Test s:tree_set_collapsed_under_cursor collapse):
   call yggdrasil#tree#new(provider)
 
   call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
 
   AssertEqual 0, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
 
-  call b:yggdrasil_tree.set_collapsed_under_cursor(1, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(1)
 
   AssertEqual 1, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
@@ -304,43 +265,15 @@ Execute(Test s:tree_set_collapsed_under_cursor flip):
   call yggdrasil#tree#new(provider)
 
   call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(-1, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(-1)
 
   AssertEqual 0, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
 
-  call b:yggdrasil_tree.set_collapsed_under_cursor(-1, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(-1)
 
   AssertEqual 1, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
-
-Execute(Test s:tree_set_collapsed_under_cursor recursive):
-  call yggdrasil#tree#new(provider)
-
-  call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 1)
-
-  let root = b:yggdrasil_tree.root
-
-  AssertEqual 'Label of node 1', root.children[0].tree_item.label
-  AssertEqual 'Label of node 2', root.children[1].tree_item.label
-  AssertEqual 'Label of node 3', root.children[0].children[0].tree_item.label
-  AssertEqual 'Label of node 4', root.children[1].children[0].tree_item.label
-  AssertEqual 'Label of node 5', root.children[1].children[1].tree_item.label
-
-  AssertEqual 0, root.children[0].collapsed
-  AssertEqual 0, root.children[1].collapsed
-  AssertEqual 0, root.children[0].children[0].collapsed
-  AssertEqual 0, root.children[1].children[0].collapsed
-  AssertEqual 0, root.children[1].children[1].collapsed
-
-  call b:yggdrasil_tree.set_collapsed_under_cursor(1, 1)
-
-  AssertEqual 1, root.children[0].collapsed
-  AssertEqual 1, root.children[1].collapsed
-  AssertEqual 1, root.children[0].children[0].collapsed
-  AssertEqual 1, root.children[1].children[0].collapsed
-  AssertEqual 1, root.children[1].children[1].collapsed
 
 Execute(Test s:tree_exec_node_under_cursor):
   call yggdrasil#tree#new(provider)
@@ -350,7 +283,7 @@ Execute(Test s:tree_exec_node_under_cursor):
 
   AssertMessage 'Calling object 0!'
 
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
   call cursor(2, 1)
 
   call b:yggdrasil_tree.exec_node_under_cursor()


### PR DESCRIPTION
Implement a lookup table, updated at each rendering, to map line numbers
in the view to nodes in the tree, allowing to get the node under cursor
without relying on concealed text.

Correctly handle node labels spanning over multiple lines.

Resolves #11, #9 

Acceptance criteria:
* [x] Implement LUT
* [x] Remove concealed id
* [x] Implement multi-line labels
* [x] Update unit tests