### PR TITLE
Remove recursive collapsing of nodes

### DIFF
--- a/doc/yggdrasil.txt
+++ b/doc/yggdrasil.txt
@@ -81,11 +81,9 @@ yggdrasil#tree#new({provider})                            *yggdrasil#tree#new*
 
     The tree object has some member functions that allow to interact with it:
 
-     * set_collapsed_under_cursor({collapsed}, {recursive})
+     * set_collapsed_under_cursor({collapsed})
        If {collapsed} is 1, collapse the node currently under cursor, if it is
-       0 expand it, if it is -1 toggle its collapsing state. If {recursive} is
-       true, the change is propagated recursively to the whole subtree rooted
-       in the node under the cursor.
+       0 expand it, if it is -1 toggle its collapsing state.
 
      * exec_node_under_cursor()
        Trigger the action associated to the execution of the node currently
@@ -211,15 +209,11 @@ under the cursor in a Yggdrasil buffer are:
     <Plug>(yggdrasil-toggle-node)
     <Plug>(yggdrasil-open-node)
     <Plug>(yggdrasil-close-node)
-    <Plug>(yggdrasil-open-subtree)
-    <Plug>(yggdrasil-close-subtree)
     <Plug>(yggdrasil-execute-node)
 
 The following key bindings are provided out-of-the-box:
 >
     nmap <silent> <buffer> o    <Plug>(yggdrasil-toggle-node)
-    nmap <silent> <buffer> O    <Plug>(yggdrasil-open-subtree)
-    nmap <silent> <buffer> C    <Plug>(yggdrasil-close-subtree)
     nmap <silent> <buffer> <cr> <Plug>(yggdrasil-execute-node)
     nnoremap <silent> <buffer> q :q<cr>
 <

--- a/test/test_filetype.vader
+++ b/test/test_filetype.vader
@@ -43,31 +43,21 @@ Execute(test filetype_settings):
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-toggle-node)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(-1, v:false)<CR>'
+  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(-1)<CR>'
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-open-node)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:false, v:false)<CR>'
+  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:false)<CR>'
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-close-node)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:true, v:false)<CR>'
-  AssertMapping
-  \   'nmap',
-  \   '<Plug>(yggdrasil-open-subtree)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:false, v:true)<CR>'
-  AssertMapping
-  \   'nmap',
-  \   '<Plug>(yggdrasil-close-subtree)',
-  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:true, v:true)<CR>'
+  \   ':call b:yggdrasil_tree.set_collapsed_under_cursor(v:true)<CR>'
   AssertMapping
   \   'nmap',
   \   '<Plug>(yggdrasil-execute-node)',
   \   ':call b:yggdrasil_tree.exec_node_under_cursor()<CR>'
 
   AssertMapping 'nmap', 'o', '<Plug>(yggdrasil-toggle-node)'
-  AssertMapping 'nmap', 'O', '<Plug>(yggdrasil-open-subtree)'
-  AssertMapping 'nmap', 'C', '<Plug>(yggdrasil-close-subtree)'
   AssertMapping 'nmap', '<CR>', '<Plug>(yggdrasil-execute-node)'
   AssertMapping 'nmap', 'q', ':q<CR>'
 
@@ -78,7 +68,5 @@ Execute(test filetype_settings with g:yggdrasil_no_default_maps):
   call Filetype_settings()
 
   AssertNoMapping 'nmap', 'o'
-  AssertNoMapping 'nmap', 'O'
-  AssertNoMapping 'nmap', 'C'
   AssertNoMapping 'nmap', '<CR>'
   AssertNoMapping 'nmap', 'q'

--- a/test/test_tree.vader
+++ b/test/test_tree.vader
@@ -37,7 +37,6 @@ After:
   unlet! Node_find
   unlet! Node_level
   unlet! Node_render
-  unlet! Node_fetch_children
   unlet! Tree_render
   unlet! exec_mock
   unlet! get_children_mock
@@ -64,7 +63,6 @@ Execute(Test s:node_new):
 
 Execute(Test s:node_render):
   let Node_render = GetFunction(b:script, 'node_render')
-  let Node_fetch_children = GetFunction(b:script, 'node_fetch_children')
   let get_children_mock = GetFunctionMock()
 
   let provider.getChildren = get_children_mock.function
@@ -75,7 +73,6 @@ Execute(Test s:node_render):
   \  'children': [],
   \  'lazy_open': 0,
   \  'render': Node_render,
-  \  'fetch_children': Node_fetch_children,
   \  'object': {},
   \  'tree': {
   \    'provider': provider,
@@ -91,7 +88,6 @@ Execute(Test s:node_render):
   \  'children': [],
   \  'lazy_open': 0,
   \  'render': Node_render,
-  \  'fetch_children': Node_fetch_children,
   \  'object': {},
   \  'tree': {
   \    'provider': provider,
@@ -176,56 +172,21 @@ Execute(Test s:node_set_collapsed):
   \  'set_collapsed': Node_set_collapsed,
   \ }
 
-  call node.set_collapsed(0, 0)
+  call node.set_collapsed(0)
 
   AssertEqual 0, node.collapsed
 
-  call node.set_collapsed(1, 0)
+  call node.set_collapsed(1)
 
   AssertEqual 1, node.collapsed
 
-  call node.set_collapsed(-1, 0)
+  call node.set_collapsed(-1)
 
   AssertEqual 0, node.collapsed
 
-  call node.set_collapsed(-1, 0)
+  call node.set_collapsed(-1)
 
   AssertEqual 1, node.collapsed
-
-Execute(Test s:node_set_collapsed recursive):
-  let Node_set_collapsed = GetFunction(b:script, 'node_set_collapsed')
-  let child = {
-  \  'collapsed': 0,
-  \  'lazy_open': 0,
-  \  'set_collapsed': Node_set_collapsed,
-  \  'children': [],
-  \ }
-  let root = {
-  \  'collapsed': 0,
-  \  'lazy_open': 0,
-  \  'set_collapsed': Node_set_collapsed,
-  \  'children': [child],
-  \ }
-
-  call root.set_collapsed(0, 1)
-
-  AssertEqual 0, root.collapsed
-  AssertEqual 0, child.collapsed
-
-  call root.set_collapsed(1, 1)
-
-  AssertEqual 1, root.collapsed
-  AssertEqual 1, child.collapsed
-
-  call root.set_collapsed(-1, 1)
-
-  AssertEqual 0, root.collapsed
-  AssertEqual 0, child.collapsed
-
-  call root.set_collapsed(-1, 1)
-
-  AssertEqual 1, root.collapsed
-  AssertEqual 1, child.collapsed
 
 Execute(Test s:tree_render filetype guard):
   let Tree_render = GetFunction(b:script, 'tree_render')
@@ -269,7 +230,7 @@ Execute(Test s:tree_set_collapsed_under_cursor expand):
   AssertEqual 1, b:yggdrasil_tree.root.lazy_open
 
   call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
 
   AssertEqual 0, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
@@ -278,7 +239,7 @@ Execute(Test s:tree_set_collapsed_under_cursor expand):
   AssertEqual 'Label of node 2', b:yggdrasil_tree.root.children[1].tree_item.label
 
   call cursor(3, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
 
   let node = b:yggdrasil_tree.root.children[1]
 
@@ -290,12 +251,12 @@ Execute(Test s:tree_set_collapsed_under_cursor collapse):
   call yggdrasil#tree#new(provider)
 
   call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
 
   AssertEqual 0, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
 
-  call b:yggdrasil_tree.set_collapsed_under_cursor(1, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(1)
 
   AssertEqual 1, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
@@ -304,43 +265,15 @@ Execute(Test s:tree_set_collapsed_under_cursor flip):
   call yggdrasil#tree#new(provider)
 
   call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(-1, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(-1)
 
   AssertEqual 0, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
 
-  call b:yggdrasil_tree.set_collapsed_under_cursor(-1, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(-1)
 
   AssertEqual 1, b:yggdrasil_tree.root.collapsed
   AssertEqual 0, b:yggdrasil_tree.root.lazy_open
-
-Execute(Test s:tree_set_collapsed_under_cursor recursive):
-  call yggdrasil#tree#new(provider)
-
-  call cursor(1, 1)
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 1)
-
-  let root = b:yggdrasil_tree.root
-
-  AssertEqual 'Label of node 1', root.children[0].tree_item.label
-  AssertEqual 'Label of node 2', root.children[1].tree_item.label
-  AssertEqual 'Label of node 3', root.children[0].children[0].tree_item.label
-  AssertEqual 'Label of node 4', root.children[1].children[0].tree_item.label
-  AssertEqual 'Label of node 5', root.children[1].children[1].tree_item.label
-
-  AssertEqual 0, root.children[0].collapsed
-  AssertEqual 0, root.children[1].collapsed
-  AssertEqual 0, root.children[0].children[0].collapsed
-  AssertEqual 0, root.children[1].children[0].collapsed
-  AssertEqual 0, root.children[1].children[1].collapsed
-
-  call b:yggdrasil_tree.set_collapsed_under_cursor(1, 1)
-
-  AssertEqual 1, root.children[0].collapsed
-  AssertEqual 1, root.children[1].collapsed
-  AssertEqual 1, root.children[0].children[0].collapsed
-  AssertEqual 1, root.children[1].children[0].collapsed
-  AssertEqual 1, root.children[1].children[1].collapsed
 
 Execute(Test s:tree_exec_node_under_cursor):
   call yggdrasil#tree#new(provider)
@@ -350,7 +283,7 @@ Execute(Test s:tree_exec_node_under_cursor):
 
   AssertMessage 'Calling object 0!'
 
-  call b:yggdrasil_tree.set_collapsed_under_cursor(0, 0)
+  call b:yggdrasil_tree.set_collapsed_under_cursor(0)
   call cursor(2, 1)
 
   call b:yggdrasil_tree.exec_node_under_cursor()


### PR DESCRIPTION
There is no guarantee that the graph generated by the data source is
finite and acyclic, therefore unbounded recursive operations may
not be well defined.

Remove the feature, since it is not particularly useful and potentially
harmful for user experience.

Acceptance criteria:
* [x] Feature removed
* [x] Tests updated
* [x] Documentation updated
* [x] README.md updated