### PR TITLE
Allow subtree update

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,22 @@ let s:provider = {
 call yggdrasil#tree#new(s:provider)
 ```
 
+To notify the view of a change in the structure or representation of the tree
+nodes, because of a change inside the provider, the `update()` method can be
+used:
+```viml
+" Update the whole tree. Allows, for instance, to change the root.
+" The whole tree is collapsed, and all nodes will be queried again from the
+" provider when the user expands them again.
+call b:yggdrasil_tree.update()
+
+" Update only the node representing the integer number "2" in the above
+" example, and its subtree. Preserve the collapsing structure of the view.
+" Only the node representing "2" and its subtree will be queried again from
+" the provider.
+call b:yggdrasil_tree.update(2)
+```
+
 For a more extensive example of usage, you can check the implementation of
 [vim-ccls](https://github.com/m-pilia/vim-ccls), that makes use of
 Yggdrasil to display symbol hierarchy trees.

--- a/autoload/yggdrasil/tree.vim
+++ b/autoload/yggdrasil/tree.vim
@@ -3,7 +3,7 @@ scriptencoding utf-8
 " Callback to retrieve the tree item representation of an object.
 function! s:node_get_tree_item_cb(node, object, status, tree_item) abort
     if a:status ==? 'success'
-        let l:new_node = s:node_new(a:node.tree, a:object, a:tree_item, a:node.id)
+        let l:new_node = s:node_new(a:node.tree, a:object, a:tree_item, a:node)
         call add(a:node.children, l:new_node)
         call s:tree_render(l:new_node.tree)
     endif
@@ -26,22 +26,27 @@ function! s:node_set_collapsed(collapsed) dict abort
     let l:self.collapsed = a:collapsed < 0 ? !l:self.collapsed : !!a:collapsed
 endfunction
 
-" Return the node object whose id is equal to {id}. Note that this uses the
-" internal integer id representing the node, not the string id from the
-" provider.
-function! s:node_find(id) dict abort
-    if l:self.id == a:id
-        return l:self
+" Given a funcref {Condition}, return a list of all nodes in the subtree of
+" {node} for which {Condition} evaluates to v:true.
+function! s:search_subtree(node, Condition) abort
+    if a:Condition(a:node)
+        return [a:node]
     endif
-    if len(l:self.children) < 1
-        return v:null
+    if len(a:node.children) < 1
+        return []
     endif
-    for l:child in l:self.children
-        let l:result = l:child.find(a:id)
-        if type(l:result) == type({})
-            return l:result
-        endif
+    let l:result = []
+    for l:child in a:node.children
+        let l:result = l:result + s:search_subtree(l:child, a:Condition)
     endfor
+    return l:result
+endfunction
+
+" Execute the action associated to a node
+function! s:node_exec() dict abort
+    if has_key(l:self.tree_item, 'command')
+        call l:self.tree_item.command()
+    endif
 endfunction
 
 " Return the depth level of the node in the tree. The level is defined
@@ -66,7 +71,7 @@ function! s:node_render(level) dict abort
     endif
 
     let l:label = split(l:self.tree_item.label, "\n")
-    call extend(l:self.tree.index, map(range(len(l:label)), l:self.id))
+    call extend(l:self.tree.index, map(range(len(l:label)), 'l:self'))
 
     let l:repr = l:indent . l:mark . l:label[0]
     \          . join(map(l:label[1:], {_, l -> "\n" . l:indent . '  ' . l}))
@@ -94,7 +99,6 @@ endfunction
 " true, the children of the node will be fetched when the node is expanded by
 " the user.
 function! s:node_new(tree, object, tree_item, parent) abort
-    let l:collapsibleState = a:tree_item.collapsibleState
     let a:tree.maxid += 1
     return {
     \ 'id': a:tree.maxid,
@@ -102,12 +106,11 @@ function! s:node_new(tree, object, tree_item, parent) abort
     \ 'object': a:object,
     \ 'tree_item': a:tree_item,
     \ 'parent': a:parent,
-    \ 'collapsed': l:collapsibleState ==? 'collapsed',
-    \ 'lazy_open': l:collapsibleState ==? 'collapsed' || l:collapsibleState ==? 'expanded',
+    \ 'collapsed': a:tree_item.collapsibleState ==? 'collapsed',
+    \ 'lazy_open': a:tree_item.collapsibleState !=? 'none',
     \ 'children': [],
     \ 'level': function('s:node_level'),
-    \ 'find': function('s:node_find'),
-    \ 'exec': has_key(a:tree_item, 'command') ? a:tree_item.command : {-> 0},
+    \ 'exec': function('s:node_exec'),
     \ 'set_collapsed': function('s:node_set_collapsed'),
     \ 'render': function('s:node_render'),
     \ }
@@ -128,8 +131,7 @@ endfunction
 " Return the node currently under the cursor from the given {tree}.
 function! s:get_node_under_cursor(tree) abort
     let l:index = min([line('.'), len(a:tree.index) - 1])
-    let l:id = a:tree.index[l:index]
-    return a:tree.root.find(l:id)
+    return a:tree.index[l:index]
 endfunction
 
 " Expand or collapse the node under cursor, and render the tree.
@@ -167,10 +169,30 @@ function! s:tree_render(tree) abort
     call setpos('.', l:cursor)
 endfunction
 
-" Update the tree, e.g. if nodes have changed.
-function! s:tree_update() dict abort
-    call l:self.provider.getChildren({status, obj ->
-    \   l:self.provider.getTreeItem(function('s:tree_set_root_cb', [l:self, obj[0]]), obj[0])})
+" If {status} equals 'success', update all nodes of {tree} representing
+" an {obect} with given {tree_item} representation.
+function! s:node_update(tree, object, status, tree_item) abort
+    if a:status !=? 'success'
+        return
+    endif
+    for l:node in s:search_subtree(a:tree.root, {n -> n.object == a:object})
+        let l:node.tree_item = a:tree_item
+        let l:node.children = []
+        let l:node.lazy_open = a:tree_item.collapsibleState !=? 'none'
+    endfor
+    call s:tree_render(a:tree)
+endfunction
+
+" Update the view if nodes have changed. If called with no arguments,
+" update the whole tree. If called with an {object} as argument, update
+" all the subtrees of nodes corresponding to {object}.
+function! s:tree_update(...) dict abort
+    if a:0 < 1
+        call l:self.provider.getChildren({status, obj ->
+        \   l:self.provider.getTreeItem(function('s:tree_set_root_cb', [l:self, obj[0]]), obj[0])})
+    else
+        call l:self.provider.getTreeItem(function('s:node_update', [l:self, a:1]), a:1)
+    endif
 endfunction
 
 " Apply syntax to an Yggdrasil buffer
@@ -229,7 +251,7 @@ endfunction
 "
 " The {bufnr} stores the buffer number of the view, {maxid} is the highest
 " known internal identifier of the nodes. The {index} is a list that
-" maps line numbers to node internal indices.
+" maps line numbers to nodes.
 function! yggdrasil#tree#new(provider) abort
     let b:yggdrasil_tree = {
     \ 'bufnr': bufnr('.'),

--- a/doc/yggdrasil.txt
+++ b/doc/yggdrasil.txt
@@ -89,9 +89,12 @@ yggdrasil#tree#new({provider})                            *yggdrasil#tree#new*
        Trigger the action associated to the execution of the node currently
        under the cursor.
 
-     * update()
+     * update([{object}])
        Update the tree, used e.g. to notify the view that the structure of the
-       tree or the content of some nodes has changed.
+       tree or the content of some nodes has changed. When called with no
+       argument, the whole tree is updated (allowing for instance to change
+       the root of the tree). Otherwise, all the subtrees with root in a node
+       representing {object} will be updated.
 
     Other members of the tree object are implementation specific and not part
     of the public API.

--- a/test/test_tree.vader
+++ b/test/test_tree.vader
@@ -32,12 +32,14 @@ After:
   unlet! tree_item
   unlet! repr
   unlet! root
+  unlet! i
   unlet! Node_new
   unlet! Node_set_collapsed
-  unlet! Node_find
+  unlet! Search_subtree
   unlet! Node_level
   unlet! Node_render
   unlet! Tree_render
+  unlet! Node_update
   unlet! exec_mock
   unlet! get_children_mock
   bwipeout!
@@ -56,7 +58,6 @@ Execute(Test s:node_new):
   AssertEqual 1, node.lazy_open
   AssertEqual [], node.children
   AssertEqual type({->0}), type(node.level)
-  AssertEqual type({->0}), type(node.find)
   AssertEqual type({->0}), type(node.exec)
   AssertEqual type({->0}), type(node.set_collapsed)
   AssertEqual type({->0}), type(node.render)
@@ -147,22 +148,23 @@ Execute(Test exec):
 
   AssertEqual 1, exec_mock.count
 
-Execute(Test s:node_find):
-  let Node_find = GetFunction(b:script, 'node_find')
-  let grandsibling = {'id': 6, 'children': [], 'find': Node_find}
-  let grandchild = {'id': 5, 'children': [], 'find': Node_find}
-  let cousin = {'id': 4, 'children': [], 'find': Node_find}
-  let sibling = {'id': 3, 'children': [grandchild, grandsibling], 'find': Node_find}
-  let child = {'id': 2, 'children': [cousin], 'find': Node_find}
-  let root = {'id': 1, 'children': [child, sibling], 'find': Node_find}
+Execute(Test s:search_subtree):
+  let Search_subtree = GetFunction(b:script, 'search_subtree')
+  let grandsibling_2 = {'key': 6, 'children': []}
+  let grandsibling_1 = {'key': 6, 'children': []}
+  let grandchild = {'key': 5, 'children': []}
+  let cousin = {'key': 4, 'children': []}
+  let sibling = {'key': 3, 'children': [grandchild, grandsibling_1, grandsibling_2]}
+  let child = {'key': 2, 'children': [cousin]}
+  let root = {'key': 1, 'children': [child, sibling]}
 
-  AssertEqual v:null, root.find(0)
-  AssertEqual root, root.find(1)
-  AssertEqual child, root.find(2)
-  AssertEqual sibling, root.find(3)
-  AssertEqual cousin, root.find(4)
-  AssertEqual grandchild, root.find(5)
-  AssertEqual grandsibling, root.find(6)
+  AssertEqual [], Search_subtree(root, {n -> n.key == 0})
+  AssertEqual [root], Search_subtree(root, {n -> n.key == 1})
+  AssertEqual [child], Search_subtree(root, {n -> n.key == 2})
+  AssertEqual [sibling], Search_subtree(root, {n -> n.key == 3})
+  AssertEqual [cousin], Search_subtree(root, {n -> n.key == 4})
+  AssertEqual [grandchild], Search_subtree(root, {n -> n.key == 5})
+  AssertEqual [grandsibling_1, grandsibling_2], Search_subtree(root, {n -> n.key == 6})
 
 Execute(Test s:node_set_collapsed):
   let Node_set_collapsed = GetFunction(b:script, 'node_set_collapsed')
@@ -289,3 +291,46 @@ Execute(Test s:tree_exec_node_under_cursor):
   call b:yggdrasil_tree.exec_node_under_cursor()
 
   AssertMessage 'Calling object 1!'
+
+Execute(Test s:node_update with unsuccessful status):
+  let Node_update = GetFunction(b:script, 'node_update')
+
+  call yggdrasil#tree#new(provider)
+
+  AssertEqual 0, b:yggdrasil_tree.root.object
+
+  let tree_item = {'id': 1, 'collapsibleState': 'none', 'label': '1'}
+  call Node_update(b:yggdrasil_tree, 0, 'failure', tree_item)
+
+  AssertEqual 0, b:yggdrasil_tree.root.tree_item.id
+
+Execute(Test s:tree_update without argument):
+  call yggdrasil#tree#new(provider)
+
+  AssertEqual 0, b:yggdrasil_tree.root.object
+
+  let provider.root[0] = 1
+
+  call b:yggdrasil_tree.update()
+
+  AssertEqual 1, b:yggdrasil_tree.root.object
+
+Execute(Test s:tree_update with argument):
+  call yggdrasil#tree#new(provider)
+
+  " Expand all nodes
+  let i = 1
+  while i <= line('$')
+    call cursor(i, 1)
+    call b:yggdrasil_tree.set_collapsed_under_cursor(0)
+    let i += 1
+  endwhile
+
+  AssertEqual 4, b:yggdrasil_tree.root.children[1].children[0].object
+
+  " Alter the representation from the provider
+  let provider.tree[2] = [6, 5]
+
+  call b:yggdrasil_tree.update(2)
+
+  AssertEqual 6, b:yggdrasil_tree.root.children[1].children[0].object


### PR DESCRIPTION
* Add an optional argument `obj` to b:yggdrasil_tree.update(), that allows to update only `obj` and its subtree.
* Remove node_find(). Now the rendering index stores references to the nodes themselves.