### PR TITLE
Documentation and API to wipe the tree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ let s:provider = {
 \ }
 
 " Create a tree view with the given provider
+"
+" This function turns the current buffer into a tree view using data from the
+" given provider. Any pre-existing content of the buffer will be deleted
+" without warning. It is recommended to call this function within a newly
+" created buffer (usually in a new split window, floating window, or tab).
 call yggdrasil#tree#new(s:provider)
 ```
 
@@ -176,6 +181,10 @@ call b:yggdrasil_tree.update()
 " the provider.
 call b:yggdrasil_tree.update(2)
 ```
+
+All the data of the tree view is local to the buffer containing it. To destroy
+the tree view, simply wipe out its buffer with
+[`:bwipeout`](http://vimdoc.sourceforge.net/htmldoc/windows.html#:bwipeout).
 
 For a more extensive example of usage, you can check the implementation of
 [vim-ccls](https://github.com/m-pilia/vim-ccls), that makes use of

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ synchronous execution, but the methods of the data provider could be
 asynchronous (e.g. launching an external job), using the provided callback
 mechanism.
 
+After installing Yggdrasil, you can run this example by pasting the following
+script in a new file, open it within vim and executing `:source %`.
+
 ```viml
 " Minimal example of tree data. The objects are integer numbers.
 " Here the tree structure is implemented with a dictionary mapping parents to
@@ -157,6 +160,23 @@ let s:provider = {
 \ 'getTreeItem': function('s:GetTreeItem'),
 \ }
 
+" Create a new buffer and a new window for the tree view
+if exists('*nvim_open_win')
+    let s:buffer_options = {
+    \ 'anchor': 'NW',
+    \ 'style': 'minimal',
+    \ 'relative': 'cursor',
+    \ 'width': 50,
+    \ 'height': 10,
+    \ 'row': 1,
+    \ 'col': 0,
+    \ }
+    call win_gotoid(nvim_open_win(nvim_create_buf(v:false, v:true), 0, s:buffer_options))
+else
+    topleft vnew
+endif
+
+
 " Create a tree view with the given provider
 "
 " This function turns the current buffer into a tree view using data from the
@@ -182,9 +202,12 @@ call b:yggdrasil_tree.update()
 call b:yggdrasil_tree.update(2)
 ```
 
-All the data of the tree view is local to the buffer containing it. To destroy
-the tree view, simply wipe out its buffer with
-[`:bwipeout`](http://vimdoc.sourceforge.net/htmldoc/windows.html#:bwipeout).
+To destroy the tree view, call the `wipe()` method. This will
+[`wipe out`](http://vimdoc.sourceforge.net/htmldoc/windows.html#:bwipeout) the
+buffer containing the tree:
+```viml
+call b:yggdrasil_tree.wipe()
+```
 
 For a more extensive example of usage, you can check the implementation of
 [vim-ccls](https://github.com/m-pilia/vim-ccls), that makes use of
@@ -201,15 +224,14 @@ The following `<Plug>` mappings are available to interact with a tree buffer:
 <Plug>(yggdrasil-open-subtree)
 <Plug>(yggdrasil-close-subtree)
 <Plug>(yggdrasil-execute-node)
+<Plug>(yggdrasil-wipe-tree)
 ```
 
 The default key bindings are:
 ```vim
 nmap <silent> <buffer> o    <Plug>(yggdrasil-toggle-node)
-nmap <silent> <buffer> O    <Plug>(yggdrasil-open-subtree)
-nmap <silent> <buffer> C    <Plug>(yggdrasil-close-subtree)
 nmap <silent> <buffer> <cr> <Plug>(yggdrasil-execute-node)
-nnoremap <silent> <buffer> q :q<cr>
+nmap <silent> <buffer> q    <Plug>(yggdrasil-wipe-tree)
 ```
 
 They can be disabled and replaced with custom mappings:

--- a/autoload/yggdrasil/tree.vim
+++ b/autoload/yggdrasil/tree.vim
@@ -195,6 +195,11 @@ function! s:tree_update(...) dict abort
     endif
 endfunction
 
+" Destroy the tree view. Wipe out the buffer containing it.
+function! s:tree_wipe() dict abort
+    execute 'bwipeout' . l:self.bufnr
+endfunction
+
 " Apply syntax to an Yggdrasil buffer
 function! s:filetype_syntax() abort
     syntax clear
@@ -237,11 +242,13 @@ function! s:filetype_settings() abort
     nnoremap <silent> <buffer> <Plug>(yggdrasil-execute-node)
         \ :call b:yggdrasil_tree.exec_node_under_cursor()<cr>
 
+    nnoremap <silent> <buffer> <Plug>(yggdrasil-wipe-tree)
+        \ :call b:yggdrasil_tree.wipe()<cr>
+
     if !exists('g:yggdrasil_no_default_maps')
         nmap <silent> <buffer> o    <Plug>(yggdrasil-toggle-node)
         nmap <silent> <buffer> <cr> <Plug>(yggdrasil-execute-node)
-
-        nnoremap <silent> <buffer> q :q<cr>
+        nmap <silent> <buffer> q    <Plug>(yggdrasil-wipe-tree)
     endif
 endfunction
 
@@ -254,7 +261,7 @@ endfunction
 " maps line numbers to nodes.
 function! yggdrasil#tree#new(provider) abort
     let b:yggdrasil_tree = {
-    \ 'bufnr': bufnr('.'),
+    \ 'bufnr': bufnr('%'),
     \ 'maxid': -1,
     \ 'root': {},
     \ 'index': [],
@@ -262,6 +269,7 @@ function! yggdrasil#tree#new(provider) abort
     \ 'set_collapsed_under_cursor': function('s:tree_set_collapsed_under_cursor'),
     \ 'exec_node_under_cursor': function('s:tree_exec_node_under_cursor'),
     \ 'update': function('s:tree_update'),
+    \ 'wipe': function('s:tree_wipe'),
     \ }
 
     augroup vim_yggdrasil

--- a/doc/yggdrasil.txt
+++ b/doc/yggdrasil.txt
@@ -46,7 +46,9 @@ yggdrasil#tree#new({provider})                            *yggdrasil#tree#new*
 
     Turns the current buffer into an Yggdrasil tree view. Tree data is
     retrieved from the given {provider} object. The state of the tree is
-    stored in a buffer-local variable called b:yggdrasil_tree.
+    stored in a buffer-local variable called b:yggdrasil_tree. Any
+    pre-existing content of the current buffer will be deleted without
+    warning.
 
     The {provider} object is a dictionary exposing three member functions:
 
@@ -98,6 +100,8 @@ yggdrasil#tree#new({provider})                            *yggdrasil#tree#new*
 
     Other members of the tree object are implementation specific and not part
     of the public API.
+
+    Do destroy the tree view, wipe out the buffer containing it with |bwipeout|.
 
     Example:
 >

--- a/doc/yggdrasil.txt
+++ b/doc/yggdrasil.txt
@@ -98,10 +98,11 @@ yggdrasil#tree#new({provider})                            *yggdrasil#tree#new*
        the root of the tree). Otherwise, all the subtrees with root in a node
        representing {object} will be updated.
 
+     * wipe()
+       Destroy the tree view and |:bwipeout| the buffer containing it.
+
     Other members of the tree object are implementation specific and not part
     of the public API.
-
-    Do destroy the tree view, wipe out the buffer containing it with |bwipeout|.
 
     Example:
 >

--- a/test/test_filetype.vader
+++ b/test/test_filetype.vader
@@ -59,7 +59,7 @@ Execute(test filetype_settings):
 
   AssertMapping 'nmap', 'o', '<Plug>(yggdrasil-toggle-node)'
   AssertMapping 'nmap', '<CR>', '<Plug>(yggdrasil-execute-node)'
-  AssertMapping 'nmap', 'q', ':q<CR>'
+  AssertMapping 'nmap', 'q', '<Plug>(yggdrasil-wipe-tree)'
 
 Execute(test filetype_settings with g:yggdrasil_no_default_maps):
   let Filetype_settings = GetFunction(b:script, 'filetype_settings')

--- a/test/test_tree.vader
+++ b/test/test_tree.vader
@@ -215,7 +215,7 @@ Execute(Test yggdrasil#tree#new):
   call yggdrasil#tree#new(provider)
 
   AssertEqual 'yggdrasil', &ft
-  AssertEqual bufnr('.'), b:yggdrasil_tree.bufnr
+  AssertEqual bufnr('%'), b:yggdrasil_tree.bufnr
   AssertEqual 0, b:yggdrasil_tree.maxid
   AssertEqual provider, b:yggdrasil_tree.provider
   AssertEqual type({-> 0}), type(b:yggdrasil_tree.set_collapsed_under_cursor)

--- a/test/test_wipe.vader
+++ b/test/test_wipe.vader
@@ -1,0 +1,27 @@
+Before:
+  source test/utils.vim
+  source test/mock/provider.vim
+
+  let provider = GetProvider()
+  let buffer_number = bufnr('%')
+  let window_number = winnr()
+
+After:
+  unlet! provider
+  unlet! buffer_number
+  unlet! window_number
+
+Given(Buffer with some content):
+  Some text.
+  This is an example.
+Execute(Test s:tree_wipe):
+  vnew
+  call yggdrasil#tree#new(provider)
+
+  call b:yggdrasil_tree.wipe()
+
+  AssertEqual buffer_number, bufnr('%')
+  AssertEqual window_number, winnr()
+Expect(Original buffer content is unchanged):
+  Some text.
+  This is an example.


### PR DESCRIPTION
* Add information on buffer creation and destruction.
* Fix a bug in how the value of b:yggdrasil_tree.bufnr was set. The
  value was accidentally set to bufnr('.') instead of bufnr('%').
* Add a documented method to destroy the tree view and wipe the buffer
  containig it.

Resolves #16 