### PR TITLE
Fix hlsearch

### DIFF
--- a/autoload/yggdrasil/embedder.vim
+++ b/autoload/yggdrasil/embedder.vim
@@ -15,7 +15,7 @@ function! s:get_git_commit() abort
     endif
 
     let l:git = 'git --git-dir=' . shellescape(s:git_dir) . ' '
-    let l:commit = system(l:git . 'rev-parse HEAD')
+    let l:commit = matchstr(system(l:git . 'rev-parse HEAD'), '[0-9A-Fa-f]\+')
     let l:is_dirty = system(l:git . 'status --porcelain') =~? '\S'
 
     return l:commit . (l:is_dirty ? ' (dirty)' : '')

--- a/autoload/yggdrasil/tree.vim
+++ b/autoload/yggdrasil/tree.vim
@@ -222,7 +222,6 @@ function! s:filetype_settings() abort
     setlocal foldmethod=manual
     setlocal nobuflisted
     setlocal nofoldenable
-    setlocal nohlsearch
     setlocal nolist
     setlocal nomodifiable
     setlocal nonumber

--- a/test/test_filetype.vader
+++ b/test/test_filetype.vader
@@ -32,7 +32,6 @@ Execute(test filetype_settings):
   AssertEqual 'manual', &foldmethod
   AssertEqual 0, &buflisted
   AssertEqual 0, &foldenable
-  AssertEqual 0, &hlsearch
   AssertEqual 0, &list
   AssertEqual 0, &modifiable
   AssertEqual 0, &number


### PR DESCRIPTION
* Avoid altering the value of the hlsearch option, that has global scope.
* Avoid inserting trailing whitespace or non-visible characters in the SHA of the commit written by the embedder.

Fix m-pilia/vim-ccls#35