### PR TITLE
Fix unnamed register bug

### DIFF
--- a/autoload/yggdrasil/tree.vim
+++ b/autoload/yggdrasil/tree.vim
@@ -163,7 +163,7 @@ function! s:tree_render(tree) abort
     setlocal modifiable
     silent 1,$delete _
     silent 0put=l:text
-    $d
+    $d_
     setlocal nomodifiable
 
     call setpos('.', l:cursor)


### PR DESCRIPTION
Ensure that content deleted from the yggdrasil buffer during the
rendering of the tree is discarded and not stored in the unnamed
register. This fixes a bug that causes the content of the unnamed yank
register being discarded when entering an yggdrasil buffer.

Resolves #24 